### PR TITLE
Fix perl hash bangs

### DIFF
--- a/centrifuge-BuildSharedSequence.pl
+++ b/centrifuge-BuildSharedSequence.pl
@@ -1,4 +1,4 @@
-#!/bin/perl
+#!/usr/bin/env perl
 
 use strict ;
 use Getopt::Long;

--- a/centrifuge-RemoveEmptySequence.pl
+++ b/centrifuge-RemoveEmptySequence.pl
@@ -1,4 +1,4 @@
-#!/bin/perl
+#!/usr/bin/env perl
 
 # remove the headers with empty sequences. possible introduced by dustmask
 

--- a/centrifuge-RemoveN.pl
+++ b/centrifuge-RemoveN.pl
@@ -1,4 +1,4 @@
-#/bin/perl
+#!/usr/bin/env perl
 
 use strict ;
 use warnings ;

--- a/centrifuge-compress.pl
+++ b/centrifuge-compress.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Read and merge the sequence for the chosen level
 

--- a/centrifuge-kreport
+++ b/centrifuge-kreport
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Give a Kraken-style report from a Centrifuge output
 #

--- a/doc/strip_markdown.pl
+++ b/doc/strip_markdown.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 
 ##
 # strip_markdown.pl


### PR DESCRIPTION
This PR corrects the perl hash bang lines. It fixes issues #31 and #25.