### PR TITLE
Fixing some numbers in centrifuge-kreport

### DIFF
--- a/centrifuge-kreport
+++ b/centrifuge-kreport
@@ -81,6 +81,11 @@ if ($is_cnts_table) {
     $seq_count += 1/$numMatches;
   }
 }
+
+for (keys %taxo_counts) {
+  $taxo_counts{$_} = sprintf("%.0f",$taxo_counts{$_});
+}
+
 my $classified_count = $seq_count - $taxo_counts{0};
 
 my %clade_counts = %taxo_counts;

--- a/centrifuge-kreport
+++ b/centrifuge-kreport
@@ -78,7 +78,7 @@ if ($is_cnts_table) {
     next if defined $min_length && $hitLength < $min_length;
     next if defined $min_score && $score < $min_score;
     $taxo_counts{$taxid} += 1/$numMatches;
-    $seq_count++;
+    $seq_count += 1/$numMatches;
   }
 }
 my $classified_count = $seq_count - $taxo_counts{0};


### PR DESCRIPTION
Hi,

I had some issues with the centrifuge-kreport script when using the tab output from centrifuge for input, as the percentages did not add up to 100% (rooted reads and unassigned) as well all reads assigned to a rank below did not add up to all reads rooted at that level.

I solved it for me by doing the following:

1) Reads with multiple assignments are also present multiple times, so the $seq_count has to be adapted in this case.

2) As all values are rounded by printf in the end anyway, all taxa with only multimapped reads assigned and less than 1 read are reported with a 0 at the clade level, despite having percentages in the first column. I'd round them all before doing the assignments to the clade counts as they are all rounded in the end anyway. So the reads at the rooted and the clade level add up again.

Best,
Samuel