### PR TITLE
centrifuge-kreport: process "no rank" assignments

### DIFF
--- a/centrifuge-kreport
+++ b/centrifuge-kreport
@@ -76,8 +76,8 @@ if ($is_cnts_table) {
     $seq_count += $count;
   }
 } else {
-  my $header = <>;
-  my @cols = split /\s+/, $header ;
+  chomp(my $header = <>);
+  my @cols = split /\t/, $header ;
   my %headerMap ;
   for ( my $i = 0 ; $i < scalar( @cols ) ; ++$i )
   {
@@ -88,7 +88,7 @@ if ($is_cnts_table) {
   my $prevTaxID;
   while (<>) {
     #my (undef,$seqID,$taxID,$score, undef, $hitLength, $queryLength, $numMatches) = split /\t/;
-    my @cols = split /\s+/ ;
+    my @cols = split /\t/ ;
     my $readID = $cols[ $headerMap{ "readID" } ] ;
     my $seqID = $cols[ $headerMap{ "seqID" } ] ; 
     my $taxID = $cols[ $headerMap{ "taxID" } ] ; 


### PR DESCRIPTION
Currently, `centrifuge-kreport` ignores "no rank" taxonomic assignments, due to the way the `centrifuge` output is processed.  This contributes to the discrepancy in read counts, which some users have noted (e.g. [#96](https://github.com/infphilo/centrifuge/issues/96)).

For example, this `centrifuge` output:
```
readID	seqID	taxID	score	2ndBestScore	hitLength	queryLength	numMatches
read1	no rank	1	3217	0	95	146	1
read2	no rank	1	64	0	23	150	1
```
currently leads to this `centrifuge-kreport` output, which looks like 0 reads were processed:
```
  0.00	0	0	U	0	unclassified
```

The debugged version produces this:
```
  0.00	0	0	U	0	unclassified
100.00	2	2	-	1	root
```
